### PR TITLE
Use --save for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the `<br />` tag.
 Install the module into your application and save it as a dev 
 dependency in your `package.json` file  
 ```
-npm install nl2br-pipe --save-dev
+npm install nl2br-pipe --save
 ```
 
 ### <a name="usage"></a>3. Usage


### PR DESCRIPTION
A Pipe is to be used in the app. IMO, it would be preferred installing as `dependencies` and not as `devDependencies`.