### PR TITLE
Move from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nl2br-pipe",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "angular2+ pipe to transform new line character to <br />",
   "main": "src/nl2br.pipe.ts",
   "types": "index.d.ts",
@@ -30,7 +30,7 @@
     "nl2br-pipe",
     "<br />"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@angular/core": ">=2.3.1",
     "@angular/platform-browser": ">=2.3.1"
   },


### PR DESCRIPTION
Moving from dependencies to peerDependencies enables developers test and run the @latest or @next angular version such as `angular@5.0.0-rc`, avoiding conflicts with breaking changes from the @angular.

Read: https://stackoverflow.com/questions/26737819/why-use-peer-dependencies-in-npm-for-plugins