### PR TITLE
fix: security issue with sanitizer

### DIFF
--- a/src/nl2br.pipe.ts
+++ b/src/nl2br.pipe.ts
@@ -1,5 +1,5 @@
-import {Pipe, PipeTransform} from '@angular/core';
-import {DomSanitizer} from '@angular/platform-browser';
+import { Pipe, PipeTransform, SecurityContext } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 
 @Pipe({
     name: 'nl2br'
@@ -8,13 +8,15 @@ export class Nl2BrPipe implements PipeTransform {
     constructor(private sanitizer: DomSanitizer) {
     }
 
-    transform(value: string): any {
-        let result;
-        if (value) {
-            result = value.replace(/(?:\r\n|\r|\n)/g, '<br />');
-            result = this.sanitizer.bypassSecurityTrustHtml(result);
+    transform(value: string, sanitizeBeforehand: boolean): string {
+        if (typeof value !== 'string') return value // Protect against runtime errors
+
+        let textParsed = value.replace(/(?:\r\n|\r|\n)/g, '<br />')
+
+        if (sanitizeBeforehand) {
+            textParsed = this.sanitizer.sanitize(SecurityContext.HTML, textParsed)
         }
 
-        return result ? result : value;
+        return textParsed
     }
 }


### PR DESCRIPTION
Hi,
First, thank you for your library as it helped me to quickly ship an app while I was still learning Angular.

Now, you dont want to use the `bypassSecurityTrustHtml` method to bind some HTML (especially since it's just for `<br>` tags), as you bypass the built-in Angular sanitizer, and add an avoidable vulnerability to XSS attacks.

You should use the `sanitize` method with the right security context. Here are the API references :
https://angular.io/api/platform-browser/DomSanitizer#sanitize
https://angular.io/api/core/SecurityContext

Better than that, thanks to Angular, binding HTML with the `[innerHtml]` property automatically sanitizes the HTML for you with the right security context. So you don't even need to sanitize beforehand.

I still kept the sanitization as a optionnal parameter, if you want to use the `transform` method elsewhere.

In the end, I strongly recommend you and the users of your library to patch this security issue. 👍 